### PR TITLE
chore: adjust readme to clarify NGINX KIC as K8 maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repo contains the Pulumi NGINX Ingress Controller component for Kubernetes. This ingress controller
 uses NGINX as a reverse proxy and load balancer.
 
-This component wraps [the official NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx),
+This component wraps [the Kubernetes Provided NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx),
 and offers a Pulumi-friendly and strongly-typed way to manage ingress controller installations.
 
 After installing this component to your cluster, you can use it by adding the


### PR DESCRIPTION
Just a minor modification to the README to change the description of the NGINX Ingress KIC to clarify that it is the [upstream Kubernetes NGINX](https://kubernetes.github.io/ingress-nginx/) and not the [NGINX supported KIC](https://github.com/nginxinc/kubernetes-ingress) in order to (hopefully) reduce some confusion.

Happy to discuss / make changes if necessary.