### PR TITLE
fix: Can't install package with npm (#7)

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -16,5 +16,6 @@
     },
     "pulumi": {
         "resource": true
-    }
+    },
+    "files": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
Adds in missing `scripts` dir to package which contains required `install-pulumi-plugin.js` file for installation to work.