### PR TITLE
[internal] Ensure we set the version correctly in the ldflag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,7 @@ builds:
       - windows
       - linux
     ldflags:
-      - -X github.com/pulumi/pulumi-kubernetes-ingress-nginx/provider/pkg/version.Version={{.Tag }}
+      - -X github.com/pulumi/pulumi-kubernetes-ingress-nginx/pkg/version.Version={{.Tag }}
     main: ./cmd/pulumi-resource-kubernetes-ingress-nginx/
 changelog:
   skip: true

--- a/provider/pkg/version/version.go
+++ b/provider/pkg/version/version.go
@@ -15,4 +15,4 @@
 package version
 
 // Version is initialized by the Go linker to contain the semver of this build.
-var Version string = "0.0.1"
+var Version string


### PR DESCRIPTION
Fixes: #13

Previously, we assumed the go module path had /provider on the end
but it didn't and therefore we were defaulting to the v0.0.1
