### PR TITLE
Fix ControllerService.loadBalancerIP key

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1358,7 +1358,7 @@
                     },
                     "type": "object"
                 },
-                "loadBalancerIPs": {
+                "loadBalancerIP": {
                     "type": "string"
                 },
                 "loadBalancerSourceRanges": {


### PR DESCRIPTION
Closes https://github.com/pulumi/pulumi-kubernetes-ingress-nginx/issues/12

The schema seems out of sync with the docs on more properties, not sure if the schema is auto generated or not. https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx#values there 