### PR TITLE
Fix module name

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-kubernetes-ingess-nginx/sdk
+module github.com/pulumi/pulumi-kubernetes-ingress-nginx/sdk
 
 go 1.17
 


### PR DESCRIPTION
Trying to use this library from a Go project fails because the go.mod file doesn't match the URL, this should fix it.