### PR TITLE
Fixing map of maps for controller configs. This is mentioned in ticke…

### DIFF
--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -100,11 +100,11 @@ export interface ControllerArgs {
     /**
      * Will add custom configuration options to Nginx https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/.
      */
-    config?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    config?: pulumi.Input<{[key: string]: pulumi.Input<string>;}>;
     /**
      * Annotations to be added to the controller config configuration configmap.
      */
-    configAnnotations?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    configAnnotations?: pulumi.Input<{[key: string]: pulumi.Input<string>;}>;
     /**
      * Allows customization of the configmap / nginx-configmap namespace.
      */
@@ -124,7 +124,7 @@ export interface ControllerArgs {
     /**
      * Optionally customize the pod dnsConfig.
      */
-    dnsConfig?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    dnsConfig?: pulumi.Input<{[key: string]: pulumi.Input<string>;}>;
     /**
      * Optionally change this to ClusterFirstWithHostNet in case you have 'hostNetwork: true'. By default, while using host network, name resolution uses the host's DNS. If you wish nginx-controller to keep resolving names inside the k8s network, use ClusterFirstWithHostNet.
      */
@@ -144,7 +144,7 @@ export interface ControllerArgs {
     /**
      * Additional command line arguments to pass to nginx-ingress-controller E.g. to specify the default SSL certificate you can use `default-ssl-certificate: "<namespace>/<secret_name>"`.
      */
-    extraArgs?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    extraArgs?: pulumi.Input<{[key: string]: pulumi.Input<string>;}>;
     /**
      * Additional containers to be added to the controller pod. See https://github.com/lemonldap-ng-controller/lemonldap-ng-controller as example.
      */


### PR DESCRIPTION
This is mentioned in ticke #22.

With the maps of maps, it is not possible to create valid configurations 
as per: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml.

