### PR TITLE
fix: go module name

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi-kubernetes-ingess-nginx/sdk
+module github.com/pulumi/pulumi-kubernetes-ingress-nginx/sdk
 
 go 1.17
 


### PR DESCRIPTION
Hi,

some small typo which blocks the usage of go as language.
