### PR TITLE
Adding in changes for additionalProperties on annotations. 

### DIFF
--- a/examples/examples_go_test.go
+++ b/examples/examples_go_test.go
@@ -24,6 +24,7 @@ func TestGoExamples(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			p := pulumitest.NewPulumiTest(t, test.directoryName,
 				opttest.LocalProviderPath("pulumi-kubernetes-ingress-nginx", filepath.Join(getCwd(t), "..", "bin")),
+				opttest.GoModReplacement("github.com/pulumi/pulumi-kubernetes-ingress-nginx/sdk", "..", "sdk"),
 			)
 			if test.additionalConfig != nil {
 				for key, value := range test.additionalConfig {

--- a/examples/simple-nginx-go/README.md
+++ b/examples/simple-nginx-go/README.md
@@ -1,0 +1,68 @@
+# Simple NGINX Example
+
+This example demonstrates how to deploy a simple NGINX server using Pulumi and Kubernetes.
+
+## Prerequisites
+
+- [Pulumi](https://www.pulumi.com/docs/get-started/install/)
+- [Go](https://golang.org/doc/install)
+- [Kubernetes](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+## Getting Started
+
+1. Clone the repository:
+
+    ```sh
+    git clone https://github.com/pulumi/pulumi-kubernetes-ingress-nginx.git
+    cd pulumi-kubernetes-ingress-nginx/examples/simple-nginx-go
+    ```
+
+2. Install dependencies:
+
+    ```sh
+    go mod tidy
+    ```
+
+3. Modify the `go.mod` file to add the following line:
+
+    ```go
+    replace github.com/pulumi/pulumi-kubernetes-ingress-nginx/sdk => ../../sdk/
+    ```
+
+4. Deploy the NGINX server:
+
+    ```sh
+    pulumi up
+    ```
+
+5. To destroy the resources when you're done:
+
+    ```sh
+    pulumi destroy
+    ```
+
+## Testing
+
+To test the deployment, follow these steps:
+
+1. Verify that the NGINX server is running:
+
+    ```sh
+    kubectl get pods
+    ```
+
+2. Get the external IP address of the NGINX service:
+
+    ```sh
+    kubectl get svc
+    ```
+
+3. Open a web browser and navigate to the external IP address. You should see the default NGINX welcome page.
+
+## Cleanup
+
+To clean up the resources created by this example, run:
+
+```sh
+pulumi destroy
+```

--- a/examples/simple-nginx-go/go.mod
+++ b/examples/simple-nginx-go/go.mod
@@ -94,5 +94,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.5.1 // indirect
 )
-
-replace github.com/pulumi/pulumi-kubernetes-ingress-nginx/sdk/go/kubernetes-ingress-nginx => ../../sdk/

--- a/examples/simple-nginx-go/main.go
+++ b/examples/simple-nginx-go/main.go
@@ -29,6 +29,7 @@ func main() {
 					Enabled: pulumi.BoolPtr(true),
 				},
 				Service: &ingressnginx.ControllerServiceArgs{
+					Annotations:           pulumi.StringMap{"pulumi.com/test-annotation1": pulumi.String("test-value1"), "pulumi.com/test-annotation2": pulumi.String("test-value2")},
 					Type:                  pulumi.String("NodePort"),
 					ExternalTrafficPolicy: pulumi.String("Local"),
 				},

--- a/examples/simple-nginx-py/__main__.py
+++ b/examples/simple-nginx-py/__main__.py
@@ -28,7 +28,14 @@ ctrl = IngressController(
         publish_service=ControllerPublishServiceArgs(
             enabled=True,
         ),
-        service=ControllerServiceArgs(type="NodePort", external_traffic_policy="Local"),
+        service=ControllerServiceArgs(
+            annotations={
+                "pulumi.com/test-annotation1": "test-value1",
+                "pulumi.com/test-annotation2": "test-value2",
+            },
+            type="NodePort",
+            external_traffic_policy="Local"
+        ),
     ),
 )
 

--- a/examples/simple-nginx-ts/index.ts
+++ b/examples/simple-nginx-ts/index.ts
@@ -24,6 +24,10 @@ const ctrl = new nginx.IngressController("myctrl", {
             enabled: true,
         },
         service: {
+            annotations: {
+                "pulumi.com/test-annotation1": "test-value1",
+                "pulumi.com/test-annotation2": "test-value2",
+            },
             type: "NodePort",
             externalTrafficPolicy: "Local"
         }

--- a/provider/cmd/pulumi-resource-kubernetes-ingress-nginx/schema.json
+++ b/provider/cmd/pulumi-resource-kubernetes-ingress-nginx/schema.json
@@ -331,9 +331,6 @@
         "kubernetes-ingress-nginx:index:Autoscaling": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "type": "object"
                 },
                 "controllerAutoscalingBehavior": {
@@ -440,9 +437,6 @@
         "kubernetes-ingress-nginx:index:ContollerAdmissionWebhooks": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "certificate": {
@@ -515,9 +509,6 @@
                     "type": "boolean"
                 },
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "Annotations to be added to the controller Deployment or DaemonSet.",
                     "type": "object"
                 },
@@ -538,7 +529,10 @@
                 },
                 "configAnnotations": {
                     "description": "Annotations to be added to the controller config configuration configmap.",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "configMapNamespace": {
                     "description": "Allows customization of the configmap / nginx-configmap namespace.",
@@ -690,16 +684,10 @@
                     "type": "object"
                 },
                 "podAnnotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "Annotations to be added to controller pods.",
                     "type": "object"
                 },
                 "podLabels": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "description": "labels to add to the pod container metadata.",
                     "type": "object"
                 },
@@ -810,9 +798,6 @@
                     "type": "object"
                 },
                 "podAnnotations": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "priorityClassName": {
@@ -842,9 +827,6 @@
         "kubernetes-ingress-nginx:index:ControllerAdmissionWebhooksService": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "clusterIP": {
@@ -947,16 +929,10 @@
                     "type": "object"
                 },
                 "podAnnotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "Annotations to be added to default backend pods.",
                     "type": "object"
                 },
                 "podLabels": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "labels to add to the pod container metadata",
                     "type": "object"
                 },
@@ -999,9 +975,6 @@
         "kubernetes-ingress-nginx:index:ControllerDefaultBackendService": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "type": "object"
                 },
                 "clusterIP": {
@@ -1138,9 +1111,6 @@
         "kubernetes-ingress-nginx:index:ControllerMetricsPrometheusRules": {
             "properties": {
                 "additionalLabels": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "enabled": {
@@ -1161,9 +1131,6 @@
         "kubernetes-ingress-nginx:index:ControllerMetricsService": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "type": "object"
                 },
                 "clusterIP": {
@@ -1202,9 +1169,6 @@
         "kubernetes-ingress-nginx:index:ControllerMetricsServiceMonitor": {
             "properties": {
                 "additionalLabels": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "enabled": {
@@ -1308,9 +1272,6 @@
         "kubernetes-ingress-nginx:index:ControllerService": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "clusterIP": {
@@ -1345,9 +1306,6 @@
                     "description": "Enables an additional internal load balancer (besides the external one). Annotations are mandatory for the load balancer to come up. Varies with the cloud service."
                 },
                 "labels": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "loadBalancerIP": {
@@ -1398,9 +1356,6 @@
         "kubernetes-ingress-nginx:index:ControllerServiceInternal": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "enabled": {
@@ -1411,9 +1366,6 @@
                     "type": "string"
                 },
                 "labels": {
-                    "additionalProperties": {
-                        "type": "object"
-                    },
                     "type": "object"
                 },
                 "loadBalancerIPs": {
@@ -1455,9 +1407,6 @@
         "kubernetes-ingress-nginx:index:ControllerTcp": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "Annotations to be added to the tcp config configmap.",
                     "type": "object"
                 },
@@ -1470,9 +1419,6 @@
         "kubernetes-ingress-nginx:index:ControllerUdp": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "Annotations to be added to the udp config configmap.",
                     "type": "object"
                 },
@@ -1535,9 +1481,6 @@
         "kubernetes-ingress-nginx:index:KedaScaledObject": {
             "properties": {
                 "annotations": {
-                    "additionalProperties": {
-                        "type": "string"
-                    },
                     "description": "Custom annotations for ScaledObject resource.",
                     "type": "object"
                 }

--- a/sdk/dotnet/Inputs/ContollerAdmissionWebhooksArgs.cs
+++ b/sdk/dotnet/Inputs/ContollerAdmissionWebhooksArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
     public sealed class ContollerAdmissionWebhooksArgs : global::Pulumi.ResourceArgs
     {
         [Input("annotations")]
-        private InputMap<ImmutableDictionary<string, string>>? _annotations;
-        public InputMap<ImmutableDictionary<string, string>> Annotations
+        private InputMap<string>? _annotations;
+        public InputMap<string> Annotations
         {
-            get => _annotations ?? (_annotations = new InputMap<ImmutableDictionary<string, string>>());
+            get => _annotations ?? (_annotations = new InputMap<string>());
             set => _annotations = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerAdmissionWebhooksPatchArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerAdmissionWebhooksPatchArgs.cs
@@ -27,10 +27,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
         }
 
         [Input("podAnnotations")]
-        private InputMap<ImmutableDictionary<string, string>>? _podAnnotations;
-        public InputMap<ImmutableDictionary<string, string>> PodAnnotations
+        private InputMap<string>? _podAnnotations;
+        public InputMap<string> PodAnnotations
         {
-            get => _podAnnotations ?? (_podAnnotations = new InputMap<ImmutableDictionary<string, string>>());
+            get => _podAnnotations ?? (_podAnnotations = new InputMap<string>());
             set => _podAnnotations = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerAdmissionWebhooksServiceArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerAdmissionWebhooksServiceArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
     public sealed class ControllerAdmissionWebhooksServiceArgs : global::Pulumi.ResourceArgs
     {
         [Input("annotations")]
-        private InputMap<ImmutableDictionary<string, string>>? _annotations;
-        public InputMap<ImmutableDictionary<string, string>> Annotations
+        private InputMap<string>? _annotations;
+        public InputMap<string> Annotations
         {
-            get => _annotations ?? (_annotations = new InputMap<ImmutableDictionary<string, string>>());
+            get => _annotations ?? (_annotations = new InputMap<string>());
             set => _annotations = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerArgs.cs
@@ -346,14 +346,14 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
         }
 
         [Input("podLabels")]
-        private InputMap<ImmutableDictionary<string, string>>? _podLabels;
+        private InputMap<string>? _podLabels;
 
         /// <summary>
         /// labels to add to the pod container metadata.
         /// </summary>
-        public InputMap<ImmutableDictionary<string, string>> PodLabels
+        public InputMap<string> PodLabels
         {
-            get => _podLabels ?? (_podLabels = new InputMap<ImmutableDictionary<string, string>>());
+            get => _podLabels ?? (_podLabels = new InputMap<string>());
             set => _podLabels = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerMetricsPrometheusRulesArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerMetricsPrometheusRulesArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
     public sealed class ControllerMetricsPrometheusRulesArgs : global::Pulumi.ResourceArgs
     {
         [Input("additionalLabels")]
-        private InputMap<ImmutableDictionary<string, string>>? _additionalLabels;
-        public InputMap<ImmutableDictionary<string, string>> AdditionalLabels
+        private InputMap<string>? _additionalLabels;
+        public InputMap<string> AdditionalLabels
         {
-            get => _additionalLabels ?? (_additionalLabels = new InputMap<ImmutableDictionary<string, string>>());
+            get => _additionalLabels ?? (_additionalLabels = new InputMap<string>());
             set => _additionalLabels = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerMetricsServiceMonitorArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerMetricsServiceMonitorArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
     public sealed class ControllerMetricsServiceMonitorArgs : global::Pulumi.ResourceArgs
     {
         [Input("additionalLabels")]
-        private InputMap<ImmutableDictionary<string, string>>? _additionalLabels;
-        public InputMap<ImmutableDictionary<string, string>> AdditionalLabels
+        private InputMap<string>? _additionalLabels;
+        public InputMap<string> AdditionalLabels
         {
-            get => _additionalLabels ?? (_additionalLabels = new InputMap<ImmutableDictionary<string, string>>());
+            get => _additionalLabels ?? (_additionalLabels = new InputMap<string>());
             set => _additionalLabels = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerServiceArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerServiceArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
     public sealed class ControllerServiceArgs : global::Pulumi.ResourceArgs
     {
         [Input("annotations")]
-        private InputMap<ImmutableDictionary<string, string>>? _annotations;
-        public InputMap<ImmutableDictionary<string, string>> Annotations
+        private InputMap<string>? _annotations;
+        public InputMap<string> Annotations
         {
-            get => _annotations ?? (_annotations = new InputMap<ImmutableDictionary<string, string>>());
+            get => _annotations ?? (_annotations = new InputMap<string>());
             set => _annotations = value;
         }
 
@@ -63,10 +63,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
         public Input<Inputs.ControllerServiceInternalArgs>? Internal { get; set; }
 
         [Input("labels")]
-        private InputMap<ImmutableDictionary<string, string>>? _labels;
-        public InputMap<ImmutableDictionary<string, string>> Labels
+        private InputMap<string>? _labels;
+        public InputMap<string> Labels
         {
-            get => _labels ?? (_labels = new InputMap<ImmutableDictionary<string, string>>());
+            get => _labels ?? (_labels = new InputMap<string>());
             set => _labels = value;
         }
 

--- a/sdk/dotnet/Inputs/ControllerServiceInternalArgs.cs
+++ b/sdk/dotnet/Inputs/ControllerServiceInternalArgs.cs
@@ -13,10 +13,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
     public sealed class ControllerServiceInternalArgs : global::Pulumi.ResourceArgs
     {
         [Input("annotations")]
-        private InputMap<ImmutableDictionary<string, string>>? _annotations;
-        public InputMap<ImmutableDictionary<string, string>> Annotations
+        private InputMap<string>? _annotations;
+        public InputMap<string> Annotations
         {
-            get => _annotations ?? (_annotations = new InputMap<ImmutableDictionary<string, string>>());
+            get => _annotations ?? (_annotations = new InputMap<string>());
             set => _annotations = value;
         }
 
@@ -30,10 +30,10 @@ namespace Pulumi.KubernetesIngressNginx.Inputs
         public Input<string>? ExternalTrafficPolicy { get; set; }
 
         [Input("labels")]
-        private InputMap<ImmutableDictionary<string, string>>? _labels;
-        public InputMap<ImmutableDictionary<string, string>> Labels
+        private InputMap<string>? _labels;
+        public InputMap<string> Labels
         {
-            get => _labels ?? (_labels = new InputMap<ImmutableDictionary<string, string>>());
+            get => _labels ?? (_labels = new InputMap<string>());
             set => _labels = value;
         }
 

--- a/sdk/go/kubernetes-ingress-nginx/pulumiTypes.go
+++ b/sdk/go/kubernetes-ingress-nginx/pulumiTypes.go
@@ -1169,7 +1169,7 @@ func (o AutoscalingTemplatePodsTargetPtrOutput) Type() pulumi.StringPtrOutput {
 }
 
 type ContollerAdmissionWebhooks struct {
-	Annotations     map[string]map[string]string                `pulumi:"annotations"`
+	Annotations     map[string]string                           `pulumi:"annotations"`
 	Certificate     *string                                     `pulumi:"certificate"`
 	CreateSecretJob *ControllerAdmissionWebhooksCreateSecretJob `pulumi:"createSecretJob"`
 	Enabled         *bool                                       `pulumi:"enabled"`
@@ -1198,7 +1198,7 @@ type ContollerAdmissionWebhooksInput interface {
 }
 
 type ContollerAdmissionWebhooksArgs struct {
-	Annotations     pulumi.StringMapMapInput                           `pulumi:"annotations"`
+	Annotations     pulumi.StringMapInput                              `pulumi:"annotations"`
 	Certificate     pulumi.StringPtrInput                              `pulumi:"certificate"`
 	CreateSecretJob ControllerAdmissionWebhooksCreateSecretJobPtrInput `pulumi:"createSecretJob"`
 	Enabled         pulumi.BoolPtrInput                                `pulumi:"enabled"`
@@ -1292,8 +1292,8 @@ func (o ContollerAdmissionWebhooksOutput) ToContollerAdmissionWebhooksPtrOutputW
 	}).(ContollerAdmissionWebhooksPtrOutput)
 }
 
-func (o ContollerAdmissionWebhooksOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ContollerAdmissionWebhooks) map[string]map[string]string { return v.Annotations }).(pulumi.StringMapMapOutput)
+func (o ContollerAdmissionWebhooksOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ContollerAdmissionWebhooks) map[string]string { return v.Annotations }).(pulumi.StringMapOutput)
 }
 
 func (o ContollerAdmissionWebhooksOutput) Certificate() pulumi.StringPtrOutput {
@@ -1377,13 +1377,13 @@ func (o ContollerAdmissionWebhooksPtrOutput) Elem() ContollerAdmissionWebhooksOu
 	}).(ContollerAdmissionWebhooksOutput)
 }
 
-func (o ContollerAdmissionWebhooksPtrOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ContollerAdmissionWebhooks) map[string]map[string]string {
+func (o ContollerAdmissionWebhooksPtrOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ContollerAdmissionWebhooks) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.Annotations
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ContollerAdmissionWebhooksPtrOutput) Certificate() pulumi.StringPtrOutput {
@@ -1587,7 +1587,7 @@ type Controller struct {
 	// Annotations to be added to controller pods.
 	PodAnnotations map[string]string `pulumi:"podAnnotations"`
 	// labels to add to the pod container metadata.
-	PodLabels map[string]map[string]string `pulumi:"podLabels"`
+	PodLabels map[string]string `pulumi:"podLabels"`
 	// Security Context policies for controller pods.
 	PodSecurityContext *corev1.PodSecurityContext `pulumi:"podSecurityContext"`
 	PriorityClassName  *string                    `pulumi:"priorityClassName"`
@@ -1718,7 +1718,7 @@ type ControllerArgs struct {
 	// Annotations to be added to controller pods.
 	PodAnnotations pulumi.StringMapInput `pulumi:"podAnnotations"`
 	// labels to add to the pod container metadata.
-	PodLabels pulumi.StringMapMapInput `pulumi:"podLabels"`
+	PodLabels pulumi.StringMapInput `pulumi:"podLabels"`
 	// Security Context policies for controller pods.
 	PodSecurityContext corev1.PodSecurityContextPtrInput `pulumi:"podSecurityContext"`
 	PriorityClassName  pulumi.StringPtrInput             `pulumi:"priorityClassName"`
@@ -2043,8 +2043,8 @@ func (o ControllerOutput) PodAnnotations() pulumi.StringMapOutput {
 }
 
 // labels to add to the pod container metadata.
-func (o ControllerOutput) PodLabels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v Controller) map[string]map[string]string { return v.PodLabels }).(pulumi.StringMapMapOutput)
+func (o ControllerOutput) PodLabels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v Controller) map[string]string { return v.PodLabels }).(pulumi.StringMapOutput)
 }
 
 // Security Context policies for controller pods.
@@ -2588,13 +2588,13 @@ func (o ControllerPtrOutput) PodAnnotations() pulumi.StringMapOutput {
 }
 
 // labels to add to the pod container metadata.
-func (o ControllerPtrOutput) PodLabels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *Controller) map[string]map[string]string {
+func (o ControllerPtrOutput) PodLabels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *Controller) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.PodLabels
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 // Security Context policies for controller pods.
@@ -2917,10 +2917,10 @@ func (o ControllerAdmissionWebhooksCreateSecretJobPtrOutput) Resources() corev1.
 }
 
 type ControllerAdmissionWebhooksPatch struct {
-	Enabled        *bool                        `pulumi:"enabled"`
-	Image          *ControllerImage             `pulumi:"image"`
-	NodeSelector   map[string]string            `pulumi:"nodeSelector"`
-	PodAnnotations map[string]map[string]string `pulumi:"podAnnotations"`
+	Enabled        *bool             `pulumi:"enabled"`
+	Image          *ControllerImage  `pulumi:"image"`
+	NodeSelector   map[string]string `pulumi:"nodeSelector"`
+	PodAnnotations map[string]string `pulumi:"podAnnotations"`
 	// Provide a priority class name to the webhook patching job.
 	PriorityClassName *string             `pulumi:"priorityClassName"`
 	RunAsUser         *int                `pulumi:"runAsUser"`
@@ -2939,10 +2939,10 @@ type ControllerAdmissionWebhooksPatchInput interface {
 }
 
 type ControllerAdmissionWebhooksPatchArgs struct {
-	Enabled        pulumi.BoolPtrInput      `pulumi:"enabled"`
-	Image          ControllerImagePtrInput  `pulumi:"image"`
-	NodeSelector   pulumi.StringMapInput    `pulumi:"nodeSelector"`
-	PodAnnotations pulumi.StringMapMapInput `pulumi:"podAnnotations"`
+	Enabled        pulumi.BoolPtrInput     `pulumi:"enabled"`
+	Image          ControllerImagePtrInput `pulumi:"image"`
+	NodeSelector   pulumi.StringMapInput   `pulumi:"nodeSelector"`
+	PodAnnotations pulumi.StringMapInput   `pulumi:"podAnnotations"`
 	// Provide a priority class name to the webhook patching job.
 	PriorityClassName pulumi.StringPtrInput       `pulumi:"priorityClassName"`
 	RunAsUser         pulumi.IntPtrInput          `pulumi:"runAsUser"`
@@ -3038,8 +3038,8 @@ func (o ControllerAdmissionWebhooksPatchOutput) NodeSelector() pulumi.StringMapO
 	return o.ApplyT(func(v ControllerAdmissionWebhooksPatch) map[string]string { return v.NodeSelector }).(pulumi.StringMapOutput)
 }
 
-func (o ControllerAdmissionWebhooksPatchOutput) PodAnnotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerAdmissionWebhooksPatch) map[string]map[string]string { return v.PodAnnotations }).(pulumi.StringMapMapOutput)
+func (o ControllerAdmissionWebhooksPatchOutput) PodAnnotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerAdmissionWebhooksPatch) map[string]string { return v.PodAnnotations }).(pulumi.StringMapOutput)
 }
 
 // Provide a priority class name to the webhook patching job.
@@ -3106,13 +3106,13 @@ func (o ControllerAdmissionWebhooksPatchPtrOutput) NodeSelector() pulumi.StringM
 	}).(pulumi.StringMapOutput)
 }
 
-func (o ControllerAdmissionWebhooksPatchPtrOutput) PodAnnotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerAdmissionWebhooksPatch) map[string]map[string]string {
+func (o ControllerAdmissionWebhooksPatchPtrOutput) PodAnnotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerAdmissionWebhooksPatch) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.PodAnnotations
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 // Provide a priority class name to the webhook patching job.
@@ -3277,13 +3277,13 @@ func (o ControllerAdmissionWebhooksPatchWebhbookJobPtrOutput) Resources() corev1
 }
 
 type ControllerAdmissionWebhooksService struct {
-	Annotations              map[string]map[string]string `pulumi:"annotations"`
-	ClusterIP                *string                      `pulumi:"clusterIP"`
-	ExternalIPs              []string                     `pulumi:"externalIPs"`
-	LoadBalancerIPs          *string                      `pulumi:"loadBalancerIPs"`
-	LoadBalancerSourceRanges []string                     `pulumi:"loadBalancerSourceRanges"`
-	ServicePort              *int                         `pulumi:"servicePort"`
-	Type                     *string                      `pulumi:"type"`
+	Annotations              map[string]string `pulumi:"annotations"`
+	ClusterIP                *string           `pulumi:"clusterIP"`
+	ExternalIPs              []string          `pulumi:"externalIPs"`
+	LoadBalancerIPs          *string           `pulumi:"loadBalancerIPs"`
+	LoadBalancerSourceRanges []string          `pulumi:"loadBalancerSourceRanges"`
+	ServicePort              *int              `pulumi:"servicePort"`
+	Type                     *string           `pulumi:"type"`
 }
 
 // ControllerAdmissionWebhooksServiceInput is an input type that accepts ControllerAdmissionWebhooksServiceArgs and ControllerAdmissionWebhooksServiceOutput values.
@@ -3298,13 +3298,13 @@ type ControllerAdmissionWebhooksServiceInput interface {
 }
 
 type ControllerAdmissionWebhooksServiceArgs struct {
-	Annotations              pulumi.StringMapMapInput `pulumi:"annotations"`
-	ClusterIP                pulumi.StringPtrInput    `pulumi:"clusterIP"`
-	ExternalIPs              pulumi.StringArrayInput  `pulumi:"externalIPs"`
-	LoadBalancerIPs          pulumi.StringPtrInput    `pulumi:"loadBalancerIPs"`
-	LoadBalancerSourceRanges pulumi.StringArrayInput  `pulumi:"loadBalancerSourceRanges"`
-	ServicePort              pulumi.IntPtrInput       `pulumi:"servicePort"`
-	Type                     pulumi.StringPtrInput    `pulumi:"type"`
+	Annotations              pulumi.StringMapInput   `pulumi:"annotations"`
+	ClusterIP                pulumi.StringPtrInput   `pulumi:"clusterIP"`
+	ExternalIPs              pulumi.StringArrayInput `pulumi:"externalIPs"`
+	LoadBalancerIPs          pulumi.StringPtrInput   `pulumi:"loadBalancerIPs"`
+	LoadBalancerSourceRanges pulumi.StringArrayInput `pulumi:"loadBalancerSourceRanges"`
+	ServicePort              pulumi.IntPtrInput      `pulumi:"servicePort"`
+	Type                     pulumi.StringPtrInput   `pulumi:"type"`
 }
 
 func (ControllerAdmissionWebhooksServiceArgs) ElementType() reflect.Type {
@@ -3384,8 +3384,8 @@ func (o ControllerAdmissionWebhooksServiceOutput) ToControllerAdmissionWebhooksS
 	}).(ControllerAdmissionWebhooksServicePtrOutput)
 }
 
-func (o ControllerAdmissionWebhooksServiceOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerAdmissionWebhooksService) map[string]map[string]string { return v.Annotations }).(pulumi.StringMapMapOutput)
+func (o ControllerAdmissionWebhooksServiceOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerAdmissionWebhooksService) map[string]string { return v.Annotations }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerAdmissionWebhooksServiceOutput) ClusterIP() pulumi.StringPtrOutput {
@@ -3436,13 +3436,13 @@ func (o ControllerAdmissionWebhooksServicePtrOutput) Elem() ControllerAdmissionW
 	}).(ControllerAdmissionWebhooksServiceOutput)
 }
 
-func (o ControllerAdmissionWebhooksServicePtrOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerAdmissionWebhooksService) map[string]map[string]string {
+func (o ControllerAdmissionWebhooksServicePtrOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerAdmissionWebhooksService) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.Annotations
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerAdmissionWebhooksServicePtrOutput) ClusterIP() pulumi.StringPtrOutput {
@@ -5355,10 +5355,10 @@ func (o ControllerMetricsPtrOutput) ServiceMonitor() ControllerMetricsServiceMon
 }
 
 type ControllerMetricsPrometheusRules struct {
-	AdditionalLabels map[string]map[string]string `pulumi:"additionalLabels"`
-	Enabled          *bool                        `pulumi:"enabled"`
-	Namespace        *string                      `pulumi:"namespace"`
-	Rules            []map[string]string          `pulumi:"rules"`
+	AdditionalLabels map[string]string   `pulumi:"additionalLabels"`
+	Enabled          *bool               `pulumi:"enabled"`
+	Namespace        *string             `pulumi:"namespace"`
+	Rules            []map[string]string `pulumi:"rules"`
 }
 
 // ControllerMetricsPrometheusRulesInput is an input type that accepts ControllerMetricsPrometheusRulesArgs and ControllerMetricsPrometheusRulesOutput values.
@@ -5373,7 +5373,7 @@ type ControllerMetricsPrometheusRulesInput interface {
 }
 
 type ControllerMetricsPrometheusRulesArgs struct {
-	AdditionalLabels pulumi.StringMapMapInput   `pulumi:"additionalLabels"`
+	AdditionalLabels pulumi.StringMapInput      `pulumi:"additionalLabels"`
 	Enabled          pulumi.BoolPtrInput        `pulumi:"enabled"`
 	Namespace        pulumi.StringPtrInput      `pulumi:"namespace"`
 	Rules            pulumi.StringMapArrayInput `pulumi:"rules"`
@@ -5456,8 +5456,8 @@ func (o ControllerMetricsPrometheusRulesOutput) ToControllerMetricsPrometheusRul
 	}).(ControllerMetricsPrometheusRulesPtrOutput)
 }
 
-func (o ControllerMetricsPrometheusRulesOutput) AdditionalLabels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerMetricsPrometheusRules) map[string]map[string]string { return v.AdditionalLabels }).(pulumi.StringMapMapOutput)
+func (o ControllerMetricsPrometheusRulesOutput) AdditionalLabels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerMetricsPrometheusRules) map[string]string { return v.AdditionalLabels }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerMetricsPrometheusRulesOutput) Enabled() pulumi.BoolPtrOutput {
@@ -5496,13 +5496,13 @@ func (o ControllerMetricsPrometheusRulesPtrOutput) Elem() ControllerMetricsProme
 	}).(ControllerMetricsPrometheusRulesOutput)
 }
 
-func (o ControllerMetricsPrometheusRulesPtrOutput) AdditionalLabels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerMetricsPrometheusRules) map[string]map[string]string {
+func (o ControllerMetricsPrometheusRulesPtrOutput) AdditionalLabels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerMetricsPrometheusRules) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.AdditionalLabels
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerMetricsPrometheusRulesPtrOutput) Enabled() pulumi.BoolPtrOutput {
@@ -5786,9 +5786,9 @@ func (o ControllerMetricsServicePtrOutput) Type() pulumi.StringPtrOutput {
 }
 
 type ControllerMetricsServiceMonitor struct {
-	AdditionalLabels map[string]map[string]string `pulumi:"additionalLabels"`
-	Enabled          *bool                        `pulumi:"enabled"`
-	HonorLabels      *bool                        `pulumi:"honorLabels"`
+	AdditionalLabels map[string]string `pulumi:"additionalLabels"`
+	Enabled          *bool             `pulumi:"enabled"`
+	HonorLabels      *bool             `pulumi:"honorLabels"`
 	// The label to use to retrieve the job name from.
 	JobLabel          *string                      `pulumi:"jobLabel"`
 	MetricRelabelings []string                     `pulumi:"metricRelabelings"`
@@ -5810,9 +5810,9 @@ type ControllerMetricsServiceMonitorInput interface {
 }
 
 type ControllerMetricsServiceMonitorArgs struct {
-	AdditionalLabels pulumi.StringMapMapInput `pulumi:"additionalLabels"`
-	Enabled          pulumi.BoolPtrInput      `pulumi:"enabled"`
-	HonorLabels      pulumi.BoolPtrInput      `pulumi:"honorLabels"`
+	AdditionalLabels pulumi.StringMapInput `pulumi:"additionalLabels"`
+	Enabled          pulumi.BoolPtrInput   `pulumi:"enabled"`
+	HonorLabels      pulumi.BoolPtrInput   `pulumi:"honorLabels"`
 	// The label to use to retrieve the job name from.
 	JobLabel          pulumi.StringPtrInput    `pulumi:"jobLabel"`
 	MetricRelabelings pulumi.StringArrayInput  `pulumi:"metricRelabelings"`
@@ -5899,8 +5899,8 @@ func (o ControllerMetricsServiceMonitorOutput) ToControllerMetricsServiceMonitor
 	}).(ControllerMetricsServiceMonitorPtrOutput)
 }
 
-func (o ControllerMetricsServiceMonitorOutput) AdditionalLabels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerMetricsServiceMonitor) map[string]map[string]string { return v.AdditionalLabels }).(pulumi.StringMapMapOutput)
+func (o ControllerMetricsServiceMonitorOutput) AdditionalLabels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerMetricsServiceMonitor) map[string]string { return v.AdditionalLabels }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerMetricsServiceMonitorOutput) Enabled() pulumi.BoolPtrOutput {
@@ -5960,13 +5960,13 @@ func (o ControllerMetricsServiceMonitorPtrOutput) Elem() ControllerMetricsServic
 	}).(ControllerMetricsServiceMonitorOutput)
 }
 
-func (o ControllerMetricsServiceMonitorPtrOutput) AdditionalLabels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerMetricsServiceMonitor) map[string]map[string]string {
+func (o ControllerMetricsServiceMonitorPtrOutput) AdditionalLabels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerMetricsServiceMonitor) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.AdditionalLabels
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerMetricsServiceMonitorPtrOutput) Enabled() pulumi.BoolPtrOutput {
@@ -6905,11 +6905,11 @@ func (o ControllerScopePtrOutput) Namespace() pulumi.StringPtrOutput {
 }
 
 type ControllerService struct {
-	Annotations map[string]map[string]string `pulumi:"annotations"`
-	ClusterIP   *string                      `pulumi:"clusterIP"`
-	EnableHttp  *bool                        `pulumi:"enableHttp"`
-	EnableHttps *bool                        `pulumi:"enableHttps"`
-	Enabled     *bool                        `pulumi:"enabled"`
+	Annotations map[string]string `pulumi:"annotations"`
+	ClusterIP   *string           `pulumi:"clusterIP"`
+	EnableHttp  *bool             `pulumi:"enableHttp"`
+	EnableHttps *bool             `pulumi:"enableHttps"`
+	Enabled     *bool             `pulumi:"enabled"`
 	// List of IP addresses at which the controller services are available Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
 	ExternalIPs []string `pulumi:"externalIPs"`
 	// Set external traffic policy to: "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
@@ -6917,13 +6917,13 @@ type ControllerService struct {
 	// specifies the health check node port (numeric port number) for the service. If healthCheckNodePort isn’t specified, the service controller allocates a port from your cluster’s NodePort range. Ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
 	HealthCheckNodePort *int `pulumi:"healthCheckNodePort"`
 	// Enables an additional internal load balancer (besides the external one). Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
-	Internal                 *ControllerServiceInternal   `pulumi:"internal"`
-	Labels                   map[string]map[string]string `pulumi:"labels"`
-	LoadBalancerIP           *string                      `pulumi:"loadBalancerIP"`
-	LoadBalancerIPs          *string                      `pulumi:"loadBalancerIPs"`
-	LoadBalancerSourceRanges []string                     `pulumi:"loadBalancerSourceRanges"`
-	NodePorts                *ControllerServiceNodePorts  `pulumi:"nodePorts"`
-	Ports                    *ControllerPort              `pulumi:"ports"`
+	Internal                 *ControllerServiceInternal  `pulumi:"internal"`
+	Labels                   map[string]string           `pulumi:"labels"`
+	LoadBalancerIP           *string                     `pulumi:"loadBalancerIP"`
+	LoadBalancerIPs          *string                     `pulumi:"loadBalancerIPs"`
+	LoadBalancerSourceRanges []string                    `pulumi:"loadBalancerSourceRanges"`
+	NodePorts                *ControllerServiceNodePorts `pulumi:"nodePorts"`
+	Ports                    *ControllerPort             `pulumi:"ports"`
 	// Must be either "None" or "ClientIP" if set. Kubernetes will default to "None". Ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
 	SessionAffinity *string         `pulumi:"sessionAffinity"`
 	TargetPorts     *ControllerPort `pulumi:"targetPorts"`
@@ -6942,11 +6942,11 @@ type ControllerServiceInput interface {
 }
 
 type ControllerServiceArgs struct {
-	Annotations pulumi.StringMapMapInput `pulumi:"annotations"`
-	ClusterIP   pulumi.StringPtrInput    `pulumi:"clusterIP"`
-	EnableHttp  pulumi.BoolPtrInput      `pulumi:"enableHttp"`
-	EnableHttps pulumi.BoolPtrInput      `pulumi:"enableHttps"`
-	Enabled     pulumi.BoolPtrInput      `pulumi:"enabled"`
+	Annotations pulumi.StringMapInput `pulumi:"annotations"`
+	ClusterIP   pulumi.StringPtrInput `pulumi:"clusterIP"`
+	EnableHttp  pulumi.BoolPtrInput   `pulumi:"enableHttp"`
+	EnableHttps pulumi.BoolPtrInput   `pulumi:"enableHttps"`
+	Enabled     pulumi.BoolPtrInput   `pulumi:"enabled"`
 	// List of IP addresses at which the controller services are available Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
 	ExternalIPs pulumi.StringArrayInput `pulumi:"externalIPs"`
 	// Set external traffic policy to: "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
@@ -6955,7 +6955,7 @@ type ControllerServiceArgs struct {
 	HealthCheckNodePort pulumi.IntPtrInput `pulumi:"healthCheckNodePort"`
 	// Enables an additional internal load balancer (besides the external one). Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
 	Internal                 ControllerServiceInternalPtrInput  `pulumi:"internal"`
-	Labels                   pulumi.StringMapMapInput           `pulumi:"labels"`
+	Labels                   pulumi.StringMapInput              `pulumi:"labels"`
 	LoadBalancerIP           pulumi.StringPtrInput              `pulumi:"loadBalancerIP"`
 	LoadBalancerIPs          pulumi.StringPtrInput              `pulumi:"loadBalancerIPs"`
 	LoadBalancerSourceRanges pulumi.StringArrayInput            `pulumi:"loadBalancerSourceRanges"`
@@ -7044,8 +7044,8 @@ func (o ControllerServiceOutput) ToControllerServicePtrOutputWithContext(ctx con
 	}).(ControllerServicePtrOutput)
 }
 
-func (o ControllerServiceOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerService) map[string]map[string]string { return v.Annotations }).(pulumi.StringMapMapOutput)
+func (o ControllerServiceOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerService) map[string]string { return v.Annotations }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServiceOutput) ClusterIP() pulumi.StringPtrOutput {
@@ -7084,8 +7084,8 @@ func (o ControllerServiceOutput) Internal() ControllerServiceInternalPtrOutput {
 	return o.ApplyT(func(v ControllerService) *ControllerServiceInternal { return v.Internal }).(ControllerServiceInternalPtrOutput)
 }
 
-func (o ControllerServiceOutput) Labels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerService) map[string]map[string]string { return v.Labels }).(pulumi.StringMapMapOutput)
+func (o ControllerServiceOutput) Labels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerService) map[string]string { return v.Labels }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServiceOutput) LoadBalancerIP() pulumi.StringPtrOutput {
@@ -7145,13 +7145,13 @@ func (o ControllerServicePtrOutput) Elem() ControllerServiceOutput {
 	}).(ControllerServiceOutput)
 }
 
-func (o ControllerServicePtrOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerService) map[string]map[string]string {
+func (o ControllerServicePtrOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerService) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.Annotations
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServicePtrOutput) ClusterIP() pulumi.StringPtrOutput {
@@ -7230,13 +7230,13 @@ func (o ControllerServicePtrOutput) Internal() ControllerServiceInternalPtrOutpu
 	}).(ControllerServiceInternalPtrOutput)
 }
 
-func (o ControllerServicePtrOutput) Labels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerService) map[string]map[string]string {
+func (o ControllerServicePtrOutput) Labels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerService) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.Labels
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServicePtrOutput) LoadBalancerIP() pulumi.StringPtrOutput {
@@ -7476,12 +7476,12 @@ func (o ControllerServiceAccountPtrOutput) Name() pulumi.StringPtrOutput {
 }
 
 type ControllerServiceInternal struct {
-	Annotations map[string]map[string]string `pulumi:"annotations"`
-	Enabled     *bool                        `pulumi:"enabled"`
+	Annotations map[string]string `pulumi:"annotations"`
+	Enabled     *bool             `pulumi:"enabled"`
 	// Set external traffic policy to: "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-	ExternalTrafficPolicy *string                      `pulumi:"externalTrafficPolicy"`
-	Labels                map[string]map[string]string `pulumi:"labels"`
-	LoadBalancerIPs       *string                      `pulumi:"loadBalancerIPs"`
+	ExternalTrafficPolicy *string           `pulumi:"externalTrafficPolicy"`
+	Labels                map[string]string `pulumi:"labels"`
+	LoadBalancerIPs       *string           `pulumi:"loadBalancerIPs"`
 	// Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
 	LoadBalancerSourceRanges []string `pulumi:"loadBalancerSourceRanges"`
 }
@@ -7498,12 +7498,12 @@ type ControllerServiceInternalInput interface {
 }
 
 type ControllerServiceInternalArgs struct {
-	Annotations pulumi.StringMapMapInput `pulumi:"annotations"`
-	Enabled     pulumi.BoolPtrInput      `pulumi:"enabled"`
+	Annotations pulumi.StringMapInput `pulumi:"annotations"`
+	Enabled     pulumi.BoolPtrInput   `pulumi:"enabled"`
 	// Set external traffic policy to: "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
-	ExternalTrafficPolicy pulumi.StringPtrInput    `pulumi:"externalTrafficPolicy"`
-	Labels                pulumi.StringMapMapInput `pulumi:"labels"`
-	LoadBalancerIPs       pulumi.StringPtrInput    `pulumi:"loadBalancerIPs"`
+	ExternalTrafficPolicy pulumi.StringPtrInput `pulumi:"externalTrafficPolicy"`
+	Labels                pulumi.StringMapInput `pulumi:"labels"`
+	LoadBalancerIPs       pulumi.StringPtrInput `pulumi:"loadBalancerIPs"`
 	// Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.
 	LoadBalancerSourceRanges pulumi.StringArrayInput `pulumi:"loadBalancerSourceRanges"`
 }
@@ -7585,8 +7585,8 @@ func (o ControllerServiceInternalOutput) ToControllerServiceInternalPtrOutputWit
 	}).(ControllerServiceInternalPtrOutput)
 }
 
-func (o ControllerServiceInternalOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerServiceInternal) map[string]map[string]string { return v.Annotations }).(pulumi.StringMapMapOutput)
+func (o ControllerServiceInternalOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerServiceInternal) map[string]string { return v.Annotations }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServiceInternalOutput) Enabled() pulumi.BoolPtrOutput {
@@ -7598,8 +7598,8 @@ func (o ControllerServiceInternalOutput) ExternalTrafficPolicy() pulumi.StringPt
 	return o.ApplyT(func(v ControllerServiceInternal) *string { return v.ExternalTrafficPolicy }).(pulumi.StringPtrOutput)
 }
 
-func (o ControllerServiceInternalOutput) Labels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v ControllerServiceInternal) map[string]map[string]string { return v.Labels }).(pulumi.StringMapMapOutput)
+func (o ControllerServiceInternalOutput) Labels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v ControllerServiceInternal) map[string]string { return v.Labels }).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServiceInternalOutput) LoadBalancerIPs() pulumi.StringPtrOutput {
@@ -7635,13 +7635,13 @@ func (o ControllerServiceInternalPtrOutput) Elem() ControllerServiceInternalOutp
 	}).(ControllerServiceInternalOutput)
 }
 
-func (o ControllerServiceInternalPtrOutput) Annotations() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerServiceInternal) map[string]map[string]string {
+func (o ControllerServiceInternalPtrOutput) Annotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerServiceInternal) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.Annotations
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServiceInternalPtrOutput) Enabled() pulumi.BoolPtrOutput {
@@ -7663,13 +7663,13 @@ func (o ControllerServiceInternalPtrOutput) ExternalTrafficPolicy() pulumi.Strin
 	}).(pulumi.StringPtrOutput)
 }
 
-func (o ControllerServiceInternalPtrOutput) Labels() pulumi.StringMapMapOutput {
-	return o.ApplyT(func(v *ControllerServiceInternal) map[string]map[string]string {
+func (o ControllerServiceInternalPtrOutput) Labels() pulumi.StringMapOutput {
+	return o.ApplyT(func(v *ControllerServiceInternal) map[string]string {
 		if v == nil {
 			return nil
 		}
 		return v.Labels
-	}).(pulumi.StringMapMapOutput)
+	}).(pulumi.StringMapOutput)
 }
 
 func (o ControllerServiceInternalPtrOutput) LoadBalancerIPs() pulumi.StringPtrOutput {

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ContollerAdmissionWebhooksArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ContollerAdmissionWebhooksArgs.java
@@ -23,9 +23,9 @@ public final class ContollerAdmissionWebhooksArgs extends com.pulumi.resources.R
     public static final ContollerAdmissionWebhooksArgs Empty = new ContollerAdmissionWebhooksArgs();
 
     @Import(name="annotations")
-    private @Nullable Output<Map<String,Map<String,String>>> annotations;
+    private @Nullable Output<Map<String,String>> annotations;
 
-    public Optional<Output<Map<String,Map<String,String>>>> annotations() {
+    public Optional<Output<Map<String,String>>> annotations() {
         return Optional.ofNullable(this.annotations);
     }
 
@@ -165,12 +165,12 @@ public final class ContollerAdmissionWebhooksArgs extends com.pulumi.resources.R
             $ = new ContollerAdmissionWebhooksArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder annotations(@Nullable Output<Map<String,Map<String,String>>> annotations) {
+        public Builder annotations(@Nullable Output<Map<String,String>> annotations) {
             $.annotations = annotations;
             return this;
         }
 
-        public Builder annotations(Map<String,Map<String,String>> annotations) {
+        public Builder annotations(Map<String,String> annotations) {
             return annotations(Output.of(annotations));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerAdmissionWebhooksPatchArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerAdmissionWebhooksPatchArgs.java
@@ -43,9 +43,9 @@ public final class ControllerAdmissionWebhooksPatchArgs extends com.pulumi.resou
     }
 
     @Import(name="podAnnotations")
-    private @Nullable Output<Map<String,Map<String,String>>> podAnnotations;
+    private @Nullable Output<Map<String,String>> podAnnotations;
 
-    public Optional<Output<Map<String,Map<String,String>>>> podAnnotations() {
+    public Optional<Output<Map<String,String>>> podAnnotations() {
         return Optional.ofNullable(this.podAnnotations);
     }
 
@@ -135,12 +135,12 @@ public final class ControllerAdmissionWebhooksPatchArgs extends com.pulumi.resou
             return nodeSelector(Output.of(nodeSelector));
         }
 
-        public Builder podAnnotations(@Nullable Output<Map<String,Map<String,String>>> podAnnotations) {
+        public Builder podAnnotations(@Nullable Output<Map<String,String>> podAnnotations) {
             $.podAnnotations = podAnnotations;
             return this;
         }
 
-        public Builder podAnnotations(Map<String,Map<String,String>> podAnnotations) {
+        public Builder podAnnotations(Map<String,String> podAnnotations) {
             return podAnnotations(Output.of(podAnnotations));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerAdmissionWebhooksServiceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerAdmissionWebhooksServiceArgs.java
@@ -19,9 +19,9 @@ public final class ControllerAdmissionWebhooksServiceArgs extends com.pulumi.res
     public static final ControllerAdmissionWebhooksServiceArgs Empty = new ControllerAdmissionWebhooksServiceArgs();
 
     @Import(name="annotations")
-    private @Nullable Output<Map<String,Map<String,String>>> annotations;
+    private @Nullable Output<Map<String,String>> annotations;
 
-    public Optional<Output<Map<String,Map<String,String>>>> annotations() {
+    public Optional<Output<Map<String,String>>> annotations() {
         return Optional.ofNullable(this.annotations);
     }
 
@@ -97,12 +97,12 @@ public final class ControllerAdmissionWebhooksServiceArgs extends com.pulumi.res
             $ = new ControllerAdmissionWebhooksServiceArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder annotations(@Nullable Output<Map<String,Map<String,String>>> annotations) {
+        public Builder annotations(@Nullable Output<Map<String,String>> annotations) {
             $.annotations = annotations;
             return this;
         }
 
-        public Builder annotations(Map<String,Map<String,String>> annotations) {
+        public Builder annotations(Map<String,String> annotations) {
             return annotations(Output.of(annotations));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerArgs.java
@@ -656,13 +656,13 @@ public final class ControllerArgs extends com.pulumi.resources.ResourceArgs {
      * 
      */
     @Import(name="podLabels")
-    private @Nullable Output<Map<String,Map<String,String>>> podLabels;
+    private @Nullable Output<Map<String,String>> podLabels;
 
     /**
      * @return labels to add to the pod container metadata.
      * 
      */
-    public Optional<Output<Map<String,Map<String,String>>>> podLabels() {
+    public Optional<Output<Map<String,String>>> podLabels() {
         return Optional.ofNullable(this.podLabels);
     }
 
@@ -1914,7 +1914,7 @@ public final class ControllerArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder podLabels(@Nullable Output<Map<String,Map<String,String>>> podLabels) {
+        public Builder podLabels(@Nullable Output<Map<String,String>> podLabels) {
             $.podLabels = podLabels;
             return this;
         }
@@ -1925,7 +1925,7 @@ public final class ControllerArgs extends com.pulumi.resources.ResourceArgs {
          * @return builder
          * 
          */
-        public Builder podLabels(Map<String,Map<String,String>> podLabels) {
+        public Builder podLabels(Map<String,String> podLabels) {
             return podLabels(Output.of(podLabels));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerMetricsPrometheusRulesArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerMetricsPrometheusRulesArgs.java
@@ -19,9 +19,9 @@ public final class ControllerMetricsPrometheusRulesArgs extends com.pulumi.resou
     public static final ControllerMetricsPrometheusRulesArgs Empty = new ControllerMetricsPrometheusRulesArgs();
 
     @Import(name="additionalLabels")
-    private @Nullable Output<Map<String,Map<String,String>>> additionalLabels;
+    private @Nullable Output<Map<String,String>> additionalLabels;
 
-    public Optional<Output<Map<String,Map<String,String>>>> additionalLabels() {
+    public Optional<Output<Map<String,String>>> additionalLabels() {
         return Optional.ofNullable(this.additionalLabels);
     }
 
@@ -73,12 +73,12 @@ public final class ControllerMetricsPrometheusRulesArgs extends com.pulumi.resou
             $ = new ControllerMetricsPrometheusRulesArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder additionalLabels(@Nullable Output<Map<String,Map<String,String>>> additionalLabels) {
+        public Builder additionalLabels(@Nullable Output<Map<String,String>> additionalLabels) {
             $.additionalLabels = additionalLabels;
             return this;
         }
 
-        public Builder additionalLabels(Map<String,Map<String,String>> additionalLabels) {
+        public Builder additionalLabels(Map<String,String> additionalLabels) {
             return additionalLabels(Output.of(additionalLabels));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerMetricsServiceMonitorArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerMetricsServiceMonitorArgs.java
@@ -19,9 +19,9 @@ public final class ControllerMetricsServiceMonitorArgs extends com.pulumi.resour
     public static final ControllerMetricsServiceMonitorArgs Empty = new ControllerMetricsServiceMonitorArgs();
 
     @Import(name="additionalLabels")
-    private @Nullable Output<Map<String,Map<String,String>>> additionalLabels;
+    private @Nullable Output<Map<String,String>> additionalLabels;
 
-    public Optional<Output<Map<String,Map<String,String>>>> additionalLabels() {
+    public Optional<Output<Map<String,String>>> additionalLabels() {
         return Optional.ofNullable(this.additionalLabels);
     }
 
@@ -121,12 +121,12 @@ public final class ControllerMetricsServiceMonitorArgs extends com.pulumi.resour
             $ = new ControllerMetricsServiceMonitorArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder additionalLabels(@Nullable Output<Map<String,Map<String,String>>> additionalLabels) {
+        public Builder additionalLabels(@Nullable Output<Map<String,String>> additionalLabels) {
             $.additionalLabels = additionalLabels;
             return this;
         }
 
-        public Builder additionalLabels(Map<String,Map<String,String>> additionalLabels) {
+        public Builder additionalLabels(Map<String,String> additionalLabels) {
             return additionalLabels(Output.of(additionalLabels));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerServiceArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerServiceArgs.java
@@ -23,9 +23,9 @@ public final class ControllerServiceArgs extends com.pulumi.resources.ResourceAr
     public static final ControllerServiceArgs Empty = new ControllerServiceArgs();
 
     @Import(name="annotations")
-    private @Nullable Output<Map<String,Map<String,String>>> annotations;
+    private @Nullable Output<Map<String,String>> annotations;
 
-    public Optional<Output<Map<String,Map<String,String>>>> annotations() {
+    public Optional<Output<Map<String,String>>> annotations() {
         return Optional.ofNullable(this.annotations);
     }
 
@@ -118,9 +118,9 @@ public final class ControllerServiceArgs extends com.pulumi.resources.ResourceAr
     }
 
     @Import(name="labels")
-    private @Nullable Output<Map<String,Map<String,String>>> labels;
+    private @Nullable Output<Map<String,String>> labels;
 
-    public Optional<Output<Map<String,Map<String,String>>>> labels() {
+    public Optional<Output<Map<String,String>>> labels() {
         return Optional.ofNullable(this.labels);
     }
 
@@ -229,12 +229,12 @@ public final class ControllerServiceArgs extends com.pulumi.resources.ResourceAr
             $ = new ControllerServiceArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder annotations(@Nullable Output<Map<String,Map<String,String>>> annotations) {
+        public Builder annotations(@Nullable Output<Map<String,String>> annotations) {
             $.annotations = annotations;
             return this;
         }
 
-        public Builder annotations(Map<String,Map<String,String>> annotations) {
+        public Builder annotations(Map<String,String> annotations) {
             return annotations(Output.of(annotations));
         }
 
@@ -368,12 +368,12 @@ public final class ControllerServiceArgs extends com.pulumi.resources.ResourceAr
             return internal(Output.of(internal));
         }
 
-        public Builder labels(@Nullable Output<Map<String,Map<String,String>>> labels) {
+        public Builder labels(@Nullable Output<Map<String,String>> labels) {
             $.labels = labels;
             return this;
         }
 
-        public Builder labels(Map<String,Map<String,String>> labels) {
+        public Builder labels(Map<String,String> labels) {
             return labels(Output.of(labels));
         }
 

--- a/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerServiceInternalArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/kubernetesingressnginx/inputs/ControllerServiceInternalArgs.java
@@ -19,9 +19,9 @@ public final class ControllerServiceInternalArgs extends com.pulumi.resources.Re
     public static final ControllerServiceInternalArgs Empty = new ControllerServiceInternalArgs();
 
     @Import(name="annotations")
-    private @Nullable Output<Map<String,Map<String,String>>> annotations;
+    private @Nullable Output<Map<String,String>> annotations;
 
-    public Optional<Output<Map<String,Map<String,String>>>> annotations() {
+    public Optional<Output<Map<String,String>>> annotations() {
         return Optional.ofNullable(this.annotations);
     }
 
@@ -48,9 +48,9 @@ public final class ControllerServiceInternalArgs extends com.pulumi.resources.Re
     }
 
     @Import(name="labels")
-    private @Nullable Output<Map<String,Map<String,String>>> labels;
+    private @Nullable Output<Map<String,String>> labels;
 
-    public Optional<Output<Map<String,Map<String,String>>>> labels() {
+    public Optional<Output<Map<String,String>>> labels() {
         return Optional.ofNullable(this.labels);
     }
 
@@ -105,12 +105,12 @@ public final class ControllerServiceInternalArgs extends com.pulumi.resources.Re
             $ = new ControllerServiceInternalArgs(Objects.requireNonNull(defaults));
         }
 
-        public Builder annotations(@Nullable Output<Map<String,Map<String,String>>> annotations) {
+        public Builder annotations(@Nullable Output<Map<String,String>> annotations) {
             $.annotations = annotations;
             return this;
         }
 
-        public Builder annotations(Map<String,Map<String,String>> annotations) {
+        public Builder annotations(Map<String,String> annotations) {
             return annotations(Output.of(annotations));
         }
 
@@ -144,12 +144,12 @@ public final class ControllerServiceInternalArgs extends com.pulumi.resources.Re
             return externalTrafficPolicy(Output.of(externalTrafficPolicy));
         }
 
-        public Builder labels(@Nullable Output<Map<String,Map<String,String>>> labels) {
+        public Builder labels(@Nullable Output<Map<String,String>> labels) {
             $.labels = labels;
             return this;
         }
 
-        public Builder labels(Map<String,Map<String,String>> labels) {
+        public Builder labels(Map<String,String> labels) {
             return labels(Output.of(labels));
         }
 

--- a/sdk/nodejs/types/input.ts
+++ b/sdk/nodejs/types/input.ts
@@ -53,7 +53,7 @@ export interface AutoscalingTemplatePodsTargetArgs {
 }
 
 export interface ContollerAdmissionWebhooksArgs {
-    annotations?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    annotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     certificate?: pulumi.Input<string>;
     createSecretJob?: pulumi.Input<inputs.ControllerAdmissionWebhooksCreateSecretJobArgs>;
     enabled?: pulumi.Input<boolean>;
@@ -233,7 +233,7 @@ export interface ControllerArgs {
     /**
      * labels to add to the pod container metadata.
      */
-    podLabels?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    podLabels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Security Context policies for controller pods.
      */
@@ -308,7 +308,7 @@ export interface ControllerAdmissionWebhooksPatchArgs {
     enabled?: pulumi.Input<boolean>;
     image?: pulumi.Input<inputs.ControllerImageArgs>;
     nodeSelector?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    podAnnotations?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    podAnnotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     /**
      * Provide a priority class name to the webhook patching job.
      */
@@ -322,7 +322,7 @@ export interface ControllerAdmissionWebhooksPatchWebhbookJobArgs {
 }
 
 export interface ControllerAdmissionWebhooksServiceArgs {
-    annotations?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    annotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     clusterIP?: pulumi.Input<string>;
     externalIPs?: pulumi.Input<pulumi.Input<string>[]>;
     loadBalancerIPs?: pulumi.Input<string>;
@@ -455,7 +455,7 @@ export interface ControllerMetricsArgs {
 }
 
 export interface ControllerMetricsPrometheusRulesArgs {
-    additionalLabels?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    additionalLabels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     enabled?: pulumi.Input<boolean>;
     namespace?: pulumi.Input<string>;
     rules?: pulumi.Input<pulumi.Input<{[key: string]: pulumi.Input<string>}>[]>;
@@ -474,7 +474,7 @@ export interface ControllerMetricsServiceArgs {
 }
 
 export interface ControllerMetricsServiceMonitorArgs {
-    additionalLabels?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    additionalLabels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     enabled?: pulumi.Input<boolean>;
     honorLabels?: pulumi.Input<boolean>;
     /**
@@ -520,7 +520,7 @@ export interface ControllerScopeArgs {
 }
 
 export interface ControllerServiceArgs {
-    annotations?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    annotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     clusterIP?: pulumi.Input<string>;
     enableHttp?: pulumi.Input<boolean>;
     enableHttps?: pulumi.Input<boolean>;
@@ -541,7 +541,7 @@ export interface ControllerServiceArgs {
      * Enables an additional internal load balancer (besides the external one). Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
      */
     internal?: pulumi.Input<inputs.ControllerServiceInternalArgs>;
-    labels?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    labels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     loadBalancerIP?: pulumi.Input<string>;
     loadBalancerIPs?: pulumi.Input<string>;
     loadBalancerSourceRanges?: pulumi.Input<pulumi.Input<string>[]>;
@@ -562,13 +562,13 @@ export interface ControllerServiceAccountArgs {
 }
 
 export interface ControllerServiceInternalArgs {
-    annotations?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    annotations?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     enabled?: pulumi.Input<boolean>;
     /**
      * Set external traffic policy to: "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
      */
     externalTrafficPolicy?: pulumi.Input<string>;
-    labels?: pulumi.Input<{[key: string]: pulumi.Input<{[key: string]: pulumi.Input<string>}>}>;
+    labels?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
     loadBalancerIPs?: pulumi.Input<string>;
     /**
      * Restrict access For LoadBalancer service. Defaults to 0.0.0.0/0.

--- a/sdk/python/pulumi_kubernetes_ingress_nginx/_inputs.py
+++ b/sdk/python/pulumi_kubernetes_ingress_nginx/_inputs.py
@@ -461,7 +461,7 @@ class AutoscalingArgs:
 
 if not MYPY:
     class ContollerAdmissionWebhooksArgsDict(TypedDict):
-        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         certificate: NotRequired[pulumi.Input[str]]
         create_secret_job: NotRequired[pulumi.Input['ControllerAdmissionWebhooksCreateSecretJobArgsDict']]
         enabled: NotRequired[pulumi.Input[bool]]
@@ -484,7 +484,7 @@ elif False:
 @pulumi.input_type
 class ContollerAdmissionWebhooksArgs:
     def __init__(__self__, *,
-                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  certificate: Optional[pulumi.Input[str]] = None,
                  create_secret_job: Optional[pulumi.Input['ControllerAdmissionWebhooksCreateSecretJobArgs']] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
@@ -532,11 +532,11 @@ class ContollerAdmissionWebhooksArgs:
 
     @property
     @pulumi.getter
-    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "annotations")
 
     @annotations.setter
-    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "annotations", value)
 
     @property
@@ -711,7 +711,7 @@ if not MYPY:
         enabled: NotRequired[pulumi.Input[bool]]
         image: NotRequired[pulumi.Input['ControllerImageArgsDict']]
         node_selector: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
-        pod_annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        pod_annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         priority_class_name: NotRequired[pulumi.Input[str]]
         """
         Provide a priority class name to the webhook patching job.
@@ -727,7 +727,7 @@ class ControllerAdmissionWebhooksPatchArgs:
                  enabled: Optional[pulumi.Input[bool]] = None,
                  image: Optional[pulumi.Input['ControllerImageArgs']] = None,
                  node_selector: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 pod_annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 pod_annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  priority_class_name: Optional[pulumi.Input[str]] = None,
                  run_as_user: Optional[pulumi.Input[int]] = None,
                  tolerations: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.core.v1.TolerationArgs']]]] = None):
@@ -778,11 +778,11 @@ class ControllerAdmissionWebhooksPatchArgs:
 
     @property
     @pulumi.getter(name="podAnnotations")
-    def pod_annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def pod_annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "pod_annotations")
 
     @pod_annotations.setter
-    def pod_annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def pod_annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "pod_annotations", value)
 
     @property
@@ -818,7 +818,7 @@ class ControllerAdmissionWebhooksPatchArgs:
 
 if not MYPY:
     class ControllerAdmissionWebhooksServiceArgsDict(TypedDict):
-        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         cluster_ip: NotRequired[pulumi.Input[str]]
         external_ips: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
         load_balancer_ips: NotRequired[pulumi.Input[str]]
@@ -831,7 +831,7 @@ elif False:
 @pulumi.input_type
 class ControllerAdmissionWebhooksServiceArgs:
     def __init__(__self__, *,
-                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ip: Optional[pulumi.Input[str]] = None,
                  external_ips: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
                  load_balancer_ips: Optional[pulumi.Input[str]] = None,
@@ -855,11 +855,11 @@ class ControllerAdmissionWebhooksServiceArgs:
 
     @property
     @pulumi.getter
-    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "annotations")
 
     @annotations.setter
-    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "annotations", value)
 
     @property
@@ -1764,7 +1764,7 @@ class ControllerIngressClassResourceArgs:
 
 if not MYPY:
     class ControllerMetricsPrometheusRulesArgsDict(TypedDict):
-        additional_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        additional_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         enabled: NotRequired[pulumi.Input[bool]]
         namespace: NotRequired[pulumi.Input[str]]
         rules: NotRequired[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
@@ -1774,7 +1774,7 @@ elif False:
 @pulumi.input_type
 class ControllerMetricsPrometheusRulesArgs:
     def __init__(__self__, *,
-                 additional_labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 additional_labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  namespace: Optional[pulumi.Input[str]] = None,
                  rules: Optional[pulumi.Input[Sequence[pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None):
@@ -1789,11 +1789,11 @@ class ControllerMetricsPrometheusRulesArgs:
 
     @property
     @pulumi.getter(name="additionalLabels")
-    def additional_labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def additional_labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "additional_labels")
 
     @additional_labels.setter
-    def additional_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def additional_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "additional_labels", value)
 
     @property
@@ -1826,7 +1826,7 @@ class ControllerMetricsPrometheusRulesArgs:
 
 if not MYPY:
     class ControllerMetricsServiceMonitorArgsDict(TypedDict):
-        additional_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        additional_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         enabled: NotRequired[pulumi.Input[bool]]
         honor_labels: NotRequired[pulumi.Input[bool]]
         job_label: NotRequired[pulumi.Input[str]]
@@ -1844,7 +1844,7 @@ elif False:
 @pulumi.input_type
 class ControllerMetricsServiceMonitorArgs:
     def __init__(__self__, *,
-                 additional_labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 additional_labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  honor_labels: Optional[pulumi.Input[bool]] = None,
                  job_label: Optional[pulumi.Input[str]] = None,
@@ -1877,11 +1877,11 @@ class ControllerMetricsServiceMonitorArgs:
 
     @property
     @pulumi.getter(name="additionalLabels")
-    def additional_labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def additional_labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "additional_labels")
 
     @additional_labels.setter
-    def additional_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def additional_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "additional_labels", value)
 
     @property
@@ -2421,13 +2421,13 @@ class ControllerServiceAccountArgs:
 
 if not MYPY:
     class ControllerServiceInternalArgsDict(TypedDict):
-        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         enabled: NotRequired[pulumi.Input[bool]]
         external_traffic_policy: NotRequired[pulumi.Input[str]]
         """
         Set external traffic policy to: "Local" to preserve source IP on providers supporting it. Ref: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-typeloadbalancer
         """
-        labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         load_balancer_ips: NotRequired[pulumi.Input[str]]
         load_balancer_source_ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
         """
@@ -2439,10 +2439,10 @@ elif False:
 @pulumi.input_type
 class ControllerServiceInternalArgs:
     def __init__(__self__, *,
-                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  enabled: Optional[pulumi.Input[bool]] = None,
                  external_traffic_policy: Optional[pulumi.Input[str]] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  load_balancer_ips: Optional[pulumi.Input[str]] = None,
                  load_balancer_source_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None):
         """
@@ -2464,11 +2464,11 @@ class ControllerServiceInternalArgs:
 
     @property
     @pulumi.getter
-    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "annotations")
 
     @annotations.setter
-    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "annotations", value)
 
     @property
@@ -2494,11 +2494,11 @@ class ControllerServiceInternalArgs:
 
     @property
     @pulumi.getter
-    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "labels")
 
     @labels.setter
-    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "labels", value)
 
     @property
@@ -2587,7 +2587,7 @@ class ControllerServiceNodePortsArgs:
 
 if not MYPY:
     class ControllerServiceArgsDict(TypedDict):
-        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        annotations: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         cluster_ip: NotRequired[pulumi.Input[str]]
         enable_http: NotRequired[pulumi.Input[bool]]
         enable_https: NotRequired[pulumi.Input[bool]]
@@ -2608,7 +2608,7 @@ if not MYPY:
         """
         Enables an additional internal load balancer (besides the external one). Annotations are mandatory for the load balancer to come up. Varies with the cloud service.
         """
-        labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         load_balancer_ip: NotRequired[pulumi.Input[str]]
         load_balancer_ips: NotRequired[pulumi.Input[str]]
         load_balancer_source_ranges: NotRequired[pulumi.Input[Sequence[pulumi.Input[str]]]]
@@ -2626,7 +2626,7 @@ elif False:
 @pulumi.input_type
 class ControllerServiceArgs:
     def __init__(__self__, *,
-                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  cluster_ip: Optional[pulumi.Input[str]] = None,
                  enable_http: Optional[pulumi.Input[bool]] = None,
                  enable_https: Optional[pulumi.Input[bool]] = None,
@@ -2635,7 +2635,7 @@ class ControllerServiceArgs:
                  external_traffic_policy: Optional[pulumi.Input[str]] = None,
                  health_check_node_port: Optional[pulumi.Input[int]] = None,
                  internal: Optional[pulumi.Input['ControllerServiceInternalArgs']] = None,
-                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  load_balancer_ip: Optional[pulumi.Input[str]] = None,
                  load_balancer_ips: Optional[pulumi.Input[str]] = None,
                  load_balancer_source_ranges: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
@@ -2690,11 +2690,11 @@ class ControllerServiceArgs:
 
     @property
     @pulumi.getter
-    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def annotations(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "annotations")
 
     @annotations.setter
-    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def annotations(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "annotations", value)
 
     @property
@@ -2783,11 +2783,11 @@ class ControllerServiceArgs:
 
     @property
     @pulumi.getter
-    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         return pulumi.get(self, "labels")
 
     @labels.setter
-    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "labels", value)
 
     @property
@@ -3151,7 +3151,7 @@ if not MYPY:
         """
         Annotations to be added to controller pods.
         """
-        pod_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]
+        pod_labels: NotRequired[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
         """
         labels to add to the pod container metadata.
         """
@@ -3268,7 +3268,7 @@ class ControllerArgs:
                  name: Optional[pulumi.Input[str]] = None,
                  node_selector: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  pod_annotations: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
-                 pod_labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
+                 pod_labels: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  pod_security_context: Optional[pulumi.Input['pulumi_kubernetes.core.v1.PodSecurityContextArgs']] = None,
                  priority_class_name: Optional[pulumi.Input[str]] = None,
                  proxy_set_headers: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]] = None,
@@ -3327,7 +3327,7 @@ class ControllerArgs:
         :param pulumi.Input[int] min_ready_seconds: minReadySeconds to avoid killing pods before we are ready.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] node_selector: Node labels for controller pod assignment Ref: https://kubernetes.io/docs/user-guide/node-selection/.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] pod_annotations: Annotations to be added to controller pods.
-        :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]] pod_labels: labels to add to the pod container metadata.
+        :param pulumi.Input[Mapping[str, pulumi.Input[str]]] pod_labels: labels to add to the pod container metadata.
         :param pulumi.Input['pulumi_kubernetes.core.v1.PodSecurityContextArgs'] pod_security_context: Security Context policies for controller pods.
         :param pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]] proxy_set_headers: Will add custom headers before sending traffic to backends according to https://github.com/kubernetes/ingress-nginx/tree/main/docs/examples/customization/custom-headers.
         :param pulumi.Input['ControllerPublishServiceArgs'] publish_service: Allows customization of the source of the IP address or FQDN to report in the ingress status field. By default, it reads the information provided by the service. If disable, the status field reports the IP address of the node or nodes where an ingress controller pod is running.
@@ -3974,14 +3974,14 @@ class ControllerArgs:
 
     @property
     @pulumi.getter(name="podLabels")
-    def pod_labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]:
+    def pod_labels(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
         """
         labels to add to the pod container metadata.
         """
         return pulumi.get(self, "pod_labels")
 
     @pod_labels.setter
-    def pod_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[Mapping[str, pulumi.Input[str]]]]]]):
+    def pod_labels(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]):
         pulumi.set(self, "pod_labels", value)
 
     @property


### PR DESCRIPTION
Fix schema for annotations and labels (https://github.com/pulumi/pulumi-kubernetes-ingress-nginx/pull/89)
* change schema for annotations and labels of multiple types to match correct object structure

* use pulumi.String() in pulumi.StringMap in go example

* Remove redundant additionalProperties from annotations and labels