### PR TITLE
Sign Windows release binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,13 @@ on:
     - "**"
   workflow_dispatch: {}
 env:
+  AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+  AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
+  AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+  AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
+  SKIP_SIGNING: ${{ secrets.AZURE_SIGNING_CLIENT_ID == '' &&
+    secrets.AZURE_SIGNING_CLIENT_SECRET == '' && secrets.AZURE_SIGNING_TENANT_ID
+    == '' && secrets.AZURE_SIGNING_KEY_VAULT_URI == '' }}
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: kubernetes-ingress-nginx
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,6 +6,13 @@ on:
     tags:
     - v*.*.*-**
 env:
+  AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+  AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
+  AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+  AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
+  SKIP_SIGNING: ${{ secrets.AZURE_SIGNING_CLIENT_ID == '' &&
+    secrets.AZURE_SIGNING_CLIENT_SECRET == '' && secrets.AZURE_SIGNING_TENANT_ID
+    == '' && secrets.AZURE_SIGNING_KEY_VAULT_URI == '' }}
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: kubernetes-ingress-nginx
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,13 @@ on:
     - v*.*.*
     - "!v*.*.*-**"
 env:
+  AZURE_SIGNING_CLIENT_ID: ${{ secrets.AZURE_SIGNING_CLIENT_ID }}
+  AZURE_SIGNING_CLIENT_SECRET: ${{ secrets.AZURE_SIGNING_CLIENT_SECRET }}
+  AZURE_SIGNING_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}
+  AZURE_SIGNING_KEY_VAULT_URI: ${{ secrets.AZURE_SIGNING_KEY_VAULT_URI }}
+  SKIP_SIGNING: ${{ secrets.AZURE_SIGNING_CLIENT_ID == '' &&
+    secrets.AZURE_SIGNING_CLIENT_SECRET == '' && secrets.AZURE_SIGNING_TENANT_ID
+    == '' && secrets.AZURE_SIGNING_KEY_VAULT_URI == '' }}
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: kubernetes-ingress-nginx
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -2,25 +2,42 @@
 
 project_name: pulumi-kubernetes-ingress-nginx
 builds:
-- dir: provider
+- id: build-provider
+  dir: provider
   env:
   - CGO_ENABLED=0
   - GO111MODULE=on
   goos:
   - darwin
-  - windows
   - linux
   goarch:
   - amd64
   - arm64
-  ignore: []
+  ignore: &a1 []
   main: ./cmd/pulumi-resource-kubernetes-ingress-nginx/
-  ldflags:
-  - -s
-  - -w
-  - -X
-    github.com/pulumi/pulumi-kubernetes-ingress-nginx/provider/pkg/version.Version={{.Tag}}
+  ldflags: &a2
+    - -s
+    - -w
+    - -X
+      github.com/pulumi/pulumi-kubernetes-ingress-nginx/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes-ingress-nginx
+- id: build-provider-sign-windows
+  dir: provider
+  env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  goos:
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ignore: *a1
+  main: ./cmd/pulumi-resource-kubernetes-ingress-nginx/
+  ldflags: *a2
+  binary: pulumi-resource-kubernetes-ingress-nginx
+  hooks:
+    post:
+    - make sign-goreleaser-exe-{{ .Arch }}
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,25 +2,42 @@
 
 project_name: pulumi-kubernetes-ingress-nginx
 builds:
-- dir: provider
+- id: build-provider
+  dir: provider
   env:
   - CGO_ENABLED=0
   - GO111MODULE=on
   goos:
   - darwin
-  - windows
   - linux
   goarch:
   - amd64
   - arm64
-  ignore: []
+  ignore: &a1 []
   main: ./cmd/pulumi-resource-kubernetes-ingress-nginx/
-  ldflags:
-  - -s
-  - -w
-  - -X
-    github.com/pulumi/pulumi-kubernetes-ingress-nginx/provider/pkg/version.Version={{.Tag}}
+  ldflags: &a2
+    - -s
+    - -w
+    - -X
+      github.com/pulumi/pulumi-kubernetes-ingress-nginx/provider/pkg/version.Version={{.Tag}}
   binary: pulumi-resource-kubernetes-ingress-nginx
+- id: build-provider-sign-windows
+  dir: provider
+  env:
+  - CGO_ENABLED=0
+  - GO111MODULE=on
+  goos:
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ignore: *a1
+  main: ./cmd/pulumi-resource-kubernetes-ingress-nginx/
+  ldflags: *a2
+  binary: pulumi-resource-kubernetes-ingress-nginx
+  hooks:
+    post:
+    - make sign-goreleaser-exe-{{ .Arch }}
 archives:
 - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
   id: archive

--- a/Makefile
+++ b/Makefile
@@ -133,3 +133,48 @@ tidy:
 	cd provider/ && go mod tidy && cd ..
 	cd examples/ && go mod tidy && cd ..
 	cd sdk/ && go mod tidy && cd ..
+# Set these variables to enable signing of the windows binary
+AZURE_SIGNING_CLIENT_ID ?=
+AZURE_SIGNING_CLIENT_SECRET ?=
+AZURE_SIGNING_TENANT_ID ?=
+AZURE_SIGNING_KEY_VAULT_URI ?=
+SKIP_SIGNING ?=
+
+bin/jsign-6.0.jar:
+	mkdir -p bin
+	wget https://github.com/ebourg/jsign/releases/download/6.0/jsign-6.0.jar --output-document=bin/jsign-6.0.jar
+
+sign-goreleaser-exe-amd64: GORELEASER_ARCH := amd64_v1
+sign-goreleaser-exe-arm64: GORELEASER_ARCH := arm64
+
+# Set the shell to bash to allow for the use of bash syntax.
+sign-goreleaser-exe-%: SHELL:=/bin/bash
+sign-goreleaser-exe-%: bin/jsign-6.0.jar
+	@# Only sign windows binary if fully configured.
+	@# Test variables set by joining with | between and looking for || showing at least one variable is empty.
+	@# Move the binary to a temporary location and sign it there to avoid the target being up-to-date if signing fails.
+	@set -e; \
+	if [[ "${SKIP_SIGNING}" != "true" ]]; then \
+		if [[ "|${AZURE_SIGNING_CLIENT_ID}|${AZURE_SIGNING_CLIENT_SECRET}|${AZURE_SIGNING_TENANT_ID}|${AZURE_SIGNING_KEY_VAULT_URI}|" == *"||"* ]]; then \
+			echo "Can't sign windows binaries as required configuration not set: AZURE_SIGNING_CLIENT_ID, AZURE_SIGNING_CLIENT_SECRET, AZURE_SIGNING_TENANT_ID, AZURE_SIGNING_KEY_VAULT_URI"; \
+			echo "To rebuild with signing delete the unsigned windows exe file and rebuild with the fixed configuration"; \
+			if [[ "${CI}" == "true" ]]; then exit 1; fi; \
+		else \
+			file=dist/build-provider-sign-windows_windows_${GORELEASER_ARCH}/pulumi-resource-kubernetes-ingress-nginx.exe; \
+			mv $${file} $${file}.unsigned; \
+			az login --service-principal \
+				--username "${AZURE_SIGNING_CLIENT_ID}" \
+				--password "${AZURE_SIGNING_CLIENT_SECRET}" \
+				--tenant "${AZURE_SIGNING_TENANT_ID}" \
+				--output none; \
+			ACCESS_TOKEN=$$(az account get-access-token --resource "https://vault.azure.net" | jq -r .accessToken); \
+			java -jar bin/jsign-6.0.jar \
+				--storetype AZUREKEYVAULT \
+				--keystore "PulumiCodeSigning" \
+				--url "${AZURE_SIGNING_KEY_VAULT_URI}" \
+				--storepass "$${ACCESS_TOKEN}" \
+				$${file}.unsigned; \
+			mv $${file}.unsigned $${file}; \
+			az logout; \
+		fi; \
+	fi


### PR DESCRIPTION
### Proposed changes

This PR adds a new Makefile target `make sign-goreleaser-exe` target to sign all built GoReleaser windows binaries. This PR contains 2 changes:

- Makefile target
- Copied ci-mgmt workflow files for validation purposes (generated from: https://github.com/pulumi/ci-mgmt/pull/1318)

Please see the linked ci-mgmt issue for status of GitHub actions workflows to validate that the binaries are signed.
