### PR TITLE
fix(ControllerService): Change loadBalancerIPs to loadBalancerIP

### DIFF
--- a/provider/pkg/provider/chart.go
+++ b/provider/pkg/provider/chart.go
@@ -407,7 +407,7 @@ type ControllerService struct {
 	// List of IP addresses at which the controller services are available
 	// Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
 	ExternalIPs              *[]string             `pulumi:"externalIPs"`
-	LoadBalancerIP           pulumi.StringPtrInput `pulumi:"loadBalancerIPs"`
+	LoadBalancerIP           pulumi.StringPtrInput `pulumi:"loadBalancerIP"`
 	LoadBalancerSourceRanges *[]string             `pulumi:"loadBalancerSourceRanges"`
 	EnableHttp               *bool                 `pulumi:"enableHttp"`
 	EnableHttps              *bool                 `pulumi:"enableHttps"`


### PR DESCRIPTION
This pull request includes a small but important correction in the `provider/pkg/provider/chart.go` file. The change fixes a typo in the `ControllerService` struct.

* Corrected the field name from `loadBalancerIPs` to `loadBalancerIP` in the `ControllerService` struct to match the expected input type.

Pulumi Program:
```python
# Install the NGINX ingress controller to our cluster. The controller
# consists of a Pod and a Service. Install it and configure the controller
# to publish the load balancer IP address on each Ingress so that
# applications can depend on the IP address of the load balancer if needed.
ctrl = IngressController(
    "myctrl",
    controller=ControllerArgs(
        admission_webhooks=ContollerAdmissionWebhooksArgs(port=8443),
        # Remove or disable host_port since GKE Autopilot doesn't allow host ports
        # host_port=ControllerHostPortArgs(
        #     enabled=True,
        # ),
        publish_service=ControllerPublishServiceArgs(
            enabled=True,
        ),
        service=ControllerServiceArgs(
            annotations={
                "pulumi.com/test-annotation1": "test-value1",
                "pulumi.com/test-annotation2": "test-value2",
            },
            type="LoadBalancer",
            load_balancer_ip="35.193.21.91",
            external_traffic_policy="Local",
        ),
    ),
)
```
Pulumi up:
```
 pulumi up --yes
Previewing update (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/team-ce/simple-nginx-py/dev/previews/658f8a35-b53d-4cff-ac04-48affaa534ef

     Type                                                 Name                  Plan       Info
 +   pulumi:pulumi:Stack                                  simple-nginx-py-dev   create     2 warnings
 +   ├─ kubernetes:apps/v1:Deployment                     hello-k8s-second-dep  create
 +   ├─ kubernetes:apps/v1:Deployment                     hello-k8s-first-dep   create
 +   ├─ kubernetes:networking.k8s.io/v1:Ingress           hello-k8s-ingress     create
 +   ├─ kubernetes:core/v1:Service                        hello-k8s-second-svc  create
 +   ├─ kubernetes:core/v1:Service                        hello-k8s-first-svc   create
 +   └─ kubernetes-ingress-nginx:index:IngressController  myctrl                create
 +      └─ kubernetes:helm.sh/v3:Release                  myctrl-helm           create

Diagnostics:
  pulumi:pulumi:Stack (simple-nginx-py-dev):
    warning: using pulumi-resource-kubernetes-ingress-nginx from $PATH at /mnt/c/Github/Go/src/github.com/pulumi/pulumi-kubernetes-ingress-nginx/bin/pulumi-resource-kubernetes-ingress-nginx
    warning: using pulumi-resource-kubernetes-ingress-nginx from $PATH at /mnt/c/Github/Go/src/github.com/pulumi/pulumi-kubernetes-ingress-nginx/bin/pulumi-resource-kubernetes-ingress-nginx

    [Pulumi Copilot] Would you like help with these diagnostics?
    https://app.pulumi.com/team-ce/simple-nginx-py/dev/previews/658f8a35-b53d-4cff-ac04-48affaa534ef?explainFailure

Outputs:
    app_statuses     : [
        [0]: output<string>
        [1]: output<string>
    ]
    controller_status: output<string>

Resources:
    + 8 to create

Updating (dev)

View in Browser (Ctrl+O): https://app.pulumi.com/team-ce/simple-nginx-py/dev/updates/19

     Type                                                 Name                  Status             Info
 +   pulumi:pulumi:Stack                                  simple-nginx-py-dev   created (177s)     2 warnings
 +   ├─ kubernetes:apps/v1:Deployment                     hello-k8s-first-dep   created (4s)
 +   ├─ kubernetes:core/v1:Service                        hello-k8s-first-svc   created (10s)
 +   ├─ kubernetes:core/v1:Service                        hello-k8s-second-svc  created (11s)
 +   ├─ kubernetes:apps/v1:Deployment                     hello-k8s-second-dep  created (101s)
 +   ├─ kubernetes:networking.k8s.io/v1:Ingress           hello-k8s-ingress     created (174s)
 +   └─ kubernetes-ingress-nginx:index:IngressController  myctrl                created (161s)
 +      └─ kubernetes:helm.sh/v3:Release                  myctrl-helm           created (158s)

Diagnostics:
  pulumi:pulumi:Stack (simple-nginx-py-dev):
    warning: using pulumi-resource-kubernetes-ingress-nginx from $PATH at /mnt/c/Github/Go/src/github.com/pulumi/pulumi-kubernetes-ingress-nginx/bin/pulumi-resource-kubernetes-ingress-nginx
    warning: using pulumi-resource-kubernetes-ingress-nginx from $PATH at /mnt/c/Github/Go/src/github.com/pulumi/pulumi-kubernetes-ingress-nginx/bin/pulumi-resource-kubernetes-ingress-nginx

    [Pulumi Copilot] Would you like help with these diagnostics?
    https://app.pulumi.com/team-ce/simple-nginx-py/dev/updates/19?explainFailure

Outputs:
    app_statuses     : [
        [0]: {
            load_balancer: {}
        }
        [1]: {
            load_balancer: {}
        }
    ]
    controller_status: {
        app_version: "1.12.0"
        chart      : "ingress-nginx"
        name       : "myctrl-helm-8baae0ec"
        namespace  : "default"
        revision   : 1
        status     : "deployed"
        version    : "4.12.0"
    }

Resources:
    + 8 created

Duration: 3m0s
```
kubectl get svc:
```
❯ kubectl get svc
NAME                                                      TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)                      AGE
hello-k8s-first                                           ClusterIP      34.118.235.111   <none>         80/TCP                       7m56s
hello-k8s-second                                          ClusterIP      34.118.225.141   <none>         80/TCP                       7m56s
kubernetes                                                ClusterIP      34.118.224.1     <none>         443/TCP                      21h
myctrl-helm-8baae0ec-ingress-nginx-controller             LoadBalancer   34.118.239.173   35.193.21.91   80:31507/TCP,443:31058/TCP   6m6s
myctrl-helm-8baae0ec-ingress-nginx-controller-admission   ClusterIP      34.118.226.67    <none>         443/TCP                      6m6s
```

Fixes: #190